### PR TITLE
SCRUM-128: kishax-awsをMCプラグインへ統合

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ API_GATEWAY_URL=https://YOUR_API_GATEWAY_ID.execute-api.ap-northeast-1.amazonaws
 CONFIRM_URL=https://your-confirm-url.com
 HOME_SERVER_NAME=spigot
 HOME_SERVER_IP=127.0.0.1
+
+# kishax-aws Integration Settings
+REDIS_URL=redis://localhost:6379
+WEB_API_BASEURL=http://localhost:3000
+INTERNAL_API_KEY=your-internal-api-key-here

--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,3 @@ HOME_SERVER_IP=127.0.0.1
 
 # kishax-aws Integration Settings
 REDIS_URL=redis://localhost:6379
-WEB_API_BASEURL=http://localhost:3000
-INTERNAL_API_KEY=your-internal-api-key-here

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,4 @@ HOME_SERVER_IP=127.0.0.1
 
 # kishax-aws Integration Settings
 REDIS_URL=redis://localhost:6379
+QUEUE_MODE=MC

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ WORKDIR /app
 COPY . .
 
 # Build the Kishax plugins
-RUN ./gradlew build -x test
+RUN if [ ! -f "velocity/build/libs/Kishax-Velocity-3.4.0.jar" ] || [ ! -f "spigot/sv1_21_8/build/libs/Kishax-Spigot-1.21.8.jar" ]; then \
+        ./gradlew build -x test; \
+    else \
+        echo "Kishax plugins already built, skipping build step"; \
+    fi
 
 # Production stage
 FROM openjdk:21-jdk-slim

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -30,3 +30,6 @@ INSERT INTO users (name, email) VALUES
 - `docker/data/seeds/example.sql` はサンプルファイルです
 - 実際のシードファイルは `.gitignore` により Git 管理対象外となります
 - MySQLコンテナ初期化時に自動的に読み込まれます
+
+## 本番環境で忘れずに行うこと
+- 環境変数のQUEUE\_MODEをMCにする

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
   }
 
   repositories {
-    mavenLocal()
+    mavenLocal() // for net.kishax.aws:kishax-aws
     mavenCentral()
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ subprojects {
   }
 
   repositories {
+    mavenLocal()
     mavenCentral()
   }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -21,6 +21,9 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.18.3'
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
+  
+  // Kishax AWS Integration - SQS and Redis communication
+  implementation 'net.kishax:kishax-aws:1.0.0-SNAPSHOT'
 }
 
 shadowJar {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 
   // Kishax AWS Integration - SQS and Redis communication
-  implementation 'net.kishax:kishax-aws:1.0.0'
+  implementation 'net.kishax.aws:kishax-aws:1.0.0'
 }
 
 shadowJar {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,19 +11,19 @@ dependencies {
   implementation 'com.mysql:mysql-connector-j:9.4.0'
   implementation 'org.json:json:20250517'
   implementation 'com.squareup.okhttp3:okhttp:5.1.0'
-  
+
   // AWS SDK for Java v2 - SQS support
   implementation 'software.amazon.awssdk:sqs:2.25.11'
   implementation 'software.amazon.awssdk:auth:2.25.11'
   implementation 'software.amazon.awssdk:regions:2.25.11'
-  
+
   // Jackson for JSON processing
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
   implementation 'com.fasterxml.jackson.core:jackson-core:2.18.3'
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
-  
+
   // Kishax AWS Integration - SQS and Redis communication
-  implementation 'net.kishax:kishax-aws:1.0.0-SNAPSHOT'
+  implementation 'net.kishax:kishax-aws:1.0.0'
 }
 
 shadowJar {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 
   // Kishax AWS Integration - SQS and Redis communication
-  implementation 'net.kishax.aws:kishax-aws:1.0.0'
+  implementation 'net.kishax.aws:kishax-aws:1.0.1'
 }
 
 shadowJar {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 
   // Kishax AWS Integration - SQS and Redis communication
-  implementation 'net.kishax.aws:kishax-aws:1.0.1'
+  implementation 'net.kishax.aws:kishax-aws:1.0.2'
 }
 
 shadowJar {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,30 @@ services:
       retries: 5
       interval: 30s
 
+  redis:
+    image: redis:7-alpine
+    container_name: kishax-redis
+    restart: unless-stopped
+    environment:
+      TZ: Asia/Tokyo
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   kishax-server:
     build: .
     container_name: kishax-minecraft
     restart: unless-stopped
     depends_on:
       mysql:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     environment:
       MYSQL_HOST: mysql
@@ -59,6 +77,10 @@ services:
       WEB_TO_MC_QUEUE_URL: ${WEB_TO_MC_QUEUE_URL}
       MC_TO_WEB_QUEUE_URL: ${MC_TO_WEB_QUEUE_URL}
       API_GATEWAY_URL: ${API_GATEWAY_URL}
+      # Redis Configuration for kishax-aws
+      REDIS_URL: redis://redis:6379
+      WEB_API_BASEURL: ${WEB_API_BASEURL:-http://host.docker.internal:3000}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
     volumes:
       - minecraft_data:/mc/spigot/world
       - minecraft_data_nether:/mc/spigot/world_nether
@@ -78,3 +100,4 @@ volumes:
   minecraft_data_the_end:
   velocity_data:
   server_images:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,6 @@ services:
       API_GATEWAY_URL: ${API_GATEWAY_URL}
       # Redis Configuration for kishax-aws
       REDIS_URL: redis://redis:6379
-      WEB_API_BASEURL: ${WEB_API_BASEURL:-http://host.docker.internal:3000}
-      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
     volumes:
       - minecraft_data:/mc/spigot/world
       - minecraft_data_nether:/mc/spigot/world_nether

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       WEB_TO_MC_QUEUE_URL: ${WEB_TO_MC_QUEUE_URL}
       MC_TO_WEB_QUEUE_URL: ${MC_TO_WEB_QUEUE_URL}
       API_GATEWAY_URL: ${API_GATEWAY_URL}
+      # Queue Mode Configuration for kishax-aws
+      QUEUE_MODE: ${QUEUE_MODE:-MC}
       # Redis Configuration for kishax-aws
       REDIS_URL: redis://redis:6379
     volumes:

--- a/docker/data/urls.json
+++ b/docker/data/urls.json
@@ -1,14 +1,14 @@
 {
   "minecraft_servers": {
     "paper": {
-      "version": "1.21.8-30",
-      "url": "https://fill-data.papermc.io/v1/objects/d310c61899acc608b683515c5c7ef929774bfd1b90262dac965e76c7e9ea8d22/paper-1.21.8-30.jar",
-      "filename": "paper-1.21.8-30.jar"
+      "version": "1.21.8-60",
+      "url": "https://fill-data.papermc.io/v1/objects/8de7c52c3b02403503d16fac58003f1efef7dd7a0256786843927fa92ee57f1e/paper-1.21.8-60.jar",
+      "filename": "paper-1.21.8-60.jar"
     },
     "velocity": {
-      "version": "3.4.0-SNAPSHOT-525",
-      "url": "https://fill-data.papermc.io/v1/objects/52053591e7a6a572c117c5b61cb42e26389537a36d92f99da40381b18f9aac8d/velocity-3.4.0-SNAPSHOT-525.jar",
-      "filename": "velocity-3.4.0-SNAPSHOT-525.jar"
+      "version": "3.4.0-SNAPSHOT-534",
+      "url": "https://fill-data.papermc.io/v1/objects/0c8327f15976c00d97e9db9f387f3b9923403d158a2ade35dfbdfc40e5be8876/velocity-3.4.0-SNAPSHOT-534.jar",
+      "filename": "velocity-3.4.0-SNAPSHOT-534.jar"
     }
   },
   "plugins": {
@@ -40,3 +40,4 @@
     }
   }
 }
+

--- a/docker/data/velocity-kishax-config.yml
+++ b/docker/data/velocity-kishax-config.yml
@@ -28,6 +28,16 @@ AWS:
   ApiGateway:
     Endpoint: "${API_GATEWAY_URL}/discord"
 
+# Redis Configuration for kishax-aws integration
+Redis:
+  URL: "${REDIS_URL}"
+
+# Web API Configuration for kishax-aws integration
+Web:
+  API:
+    BaseURL: "${WEB_API_BASEURL}"
+    InternalKey: "${INTERNAL_API_KEY}"
+
 Debug:
   Mode: false
   Test: false

--- a/docker/data/velocity-kishax-config.yml
+++ b/docker/data/velocity-kishax-config.yml
@@ -32,12 +32,6 @@ AWS:
 Redis:
   URL: "${REDIS_URL}"
 
-# Web API Configuration for kishax-aws integration
-Web:
-  API:
-    BaseURL: "${WEB_API_BASEURL}"
-    InternalKey: "${INTERNAL_API_KEY}"
-
 Debug:
   Mode: false
   Test: false

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -24,12 +24,12 @@ dependencies {
   shadowImpl 'com.fasterxml.jackson.core:jackson-core:2.18.2'
   shadowImpl 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
   shadowImpl 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
-  
+
   // AWS SDK for Java v2 - explicit dependencies for compilation
   compileOnly 'software.amazon.awssdk:sqs:2.25.11'
   compileOnly 'software.amazon.awssdk:auth:2.25.11'
   compileOnly 'software.amazon.awssdk:regions:2.25.11'
-  
+
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
   shadowImpl2 'net.kishax.aws:kishax-aws:1.0.0'

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -24,6 +24,8 @@ dependencies {
   shadowImpl 'com.fasterxml.jackson.core:jackson-core:2.18.2'
   shadowImpl 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
   shadowImpl 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
+  shadowImpl 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.2'
+  shadowImpl 'io.lettuce:lettuce-core:6.3.0.RELEASE'
 
   // AWS SDK for Java v2 - explicit dependencies for compilation
   compileOnly 'software.amazon.awssdk:sqs:2.25.11'

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
-  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.0'
+  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.1'
 }
 
 build {

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
-  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.1'
+  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.2'
 }
 
 build {

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
-  shadowImpl2 'net.kishax:kishax-aws:1.0.0-SNAPSHOT'
+  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.0'
 }
 
 build {

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
+  shadowImpl2 'net.kishax:kishax-aws:1.0.0-SNAPSHOT'
 }
 
 build {

--- a/velocity/src/main/java/net/kishax/mc/velocity/Main.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/Main.java
@@ -148,7 +148,7 @@ public class Main {
     return injector;
   }
   
-  private void initializeSqsServices() {
+  private void initializeSqsServices() throws Exception {
     try {
       VelocityConfig config = getInjector().getInstance(VelocityConfig.class);
       AwsConfig awsConfig = getInjector().getInstance(AwsConfig.class);

--- a/velocity/src/main/java/net/kishax/mc/velocity/Main.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/Main.java
@@ -173,10 +173,10 @@ public class Main {
       
       // kishax-aws統合のためのConfiguration作成
       System.setProperty("AWS_REGION", region);
-      System.setProperty("AWS_SQS_ACCESSKEYID", accessKey);
-      System.setProperty("AWS_SQS_SECRETACCESSKEY", secretKey);
-      System.setProperty("AWS_SQS_MCTOWEB_QUEUE_URL", mcToWebQueueUrl);
-      System.setProperty("AWS_SQS_WEBTOMCQUEUEURL", webToMcQueueUrl);
+      System.setProperty("MC_WEB_SQS_ACCESS_KEY_ID", accessKey);
+      System.setProperty("MC_WEB_SQS_SECRET_ACCESS_KEY", secretKey);
+      System.setProperty("MC_TO_WEB_QUEUE_URL", mcToWebQueueUrl);
+      System.setProperty("WEB_TO_MC_QUEUE_URL", webToMcQueueUrl);
       System.setProperty("REDIS_URL", redisUrl);
       
       net.kishax.aws.Configuration kishaxConfig = new net.kishax.aws.Configuration();

--- a/velocity/src/main/java/net/kishax/mc/velocity/Main.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/Main.java
@@ -50,7 +50,7 @@ public class Main {
   private boolean isEnable = false;
   
   // kishax-aws components for shutdown
-  private net.kishax.aws.SqsWorker kishaxSqsWorker;
+  private static net.kishax.aws.SqsWorker kishaxSqsWorker;
   private net.kishax.aws.RedisClient kishaxRedisClient;
 
   @Inject
@@ -148,6 +148,13 @@ public class Main {
     return injector;
   }
   
+  /**
+   * Get the kishax-aws SqsWorker instance
+   */
+  public static net.kishax.aws.SqsWorker getKishaxSqsWorker() {
+    return kishaxSqsWorker;
+  }
+  
   private void initializeSqsServices() throws Exception {
     try {
       VelocityConfig config = getInjector().getInstance(VelocityConfig.class);
@@ -188,7 +195,7 @@ public class Main {
       logger.info("✅ kishax-aws SQSワーカーが開始されました（QUEUE_MODE対応）");
       
       // グローバル参照のため静的フィールドに保存（後でシャットダウン時に使用）
-      this.kishaxSqsWorker = sqsWorker;
+      Main.kishaxSqsWorker = sqsWorker;
       this.kishaxRedisClient = kishaxConfig.createRedisClient();
       
     } catch (Exception e) {

--- a/velocity/src/main/java/net/kishax/mc/velocity/Main.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/Main.java
@@ -182,20 +182,14 @@ public class Main {
       net.kishax.aws.Configuration kishaxConfig = new net.kishax.aws.Configuration();
       kishaxConfig.validate();
       
-      // kishax-awsコンポーネントを初期化
-      software.amazon.awssdk.services.sqs.SqsClient awsSqsClient = kishaxConfig.createSqsClient();
-      net.kishax.aws.RedisClient redisClient = kishaxConfig.createRedisClient();
-      net.kishax.aws.WebToMcMessageSender webToMcSender = new net.kishax.aws.WebToMcMessageSender(awsSqsClient, webToMcQueueUrl);
-      
-      // SqsWorkerの初期化と開始（DatabaseClientなし）
-      net.kishax.aws.SqsWorker sqsWorker = new net.kishax.aws.SqsWorker(
-          awsSqsClient, mcToWebQueueUrl, redisClient, webToMcSender);
+      // SqsWorkerをQUEUE_MODE対応で初期化（kishax-awsが自動でキューを選択）
+      net.kishax.aws.SqsWorker sqsWorker = net.kishax.aws.SqsWorker.createWithQueueMode(kishaxConfig);
       sqsWorker.start();
-      logger.info("✅ kishax-aws SQSワーカーが開始されました（Redis通信のみ）");
+      logger.info("✅ kishax-aws SQSワーカーが開始されました（QUEUE_MODE対応）");
       
       // グローバル参照のため静的フィールドに保存（後でシャットダウン時に使用）
       this.kishaxSqsWorker = sqsWorker;
-      this.kishaxRedisClient = redisClient;
+      this.kishaxRedisClient = kishaxConfig.createRedisClient();
       
     } catch (Exception e) {
       logger.error("kishax-aws SQS サービスの初期化に失敗しました: {}", e.getMessage());

--- a/velocity/src/main/java/net/kishax/mc/velocity/socket/handlers/AuthTokenHandler.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/socket/handlers/AuthTokenHandler.java
@@ -23,13 +23,24 @@ public class AuthTokenHandler {
       logger.info("Received auth token from Spigot for player: {} (action: {})", 
           authToken.who.name, authToken.action);
 
-      // AWS SQSサービスが利用可能かチェック
+      // kishax-aws SQSワーカー経由で送信（推奨）
+      // 注意: Main.kishaxSqsWorkerがnullでない場合のみ使用
       try {
-        AwsSqsService awsSqsService = awsSqsServiceProvider.get();
-        awsSqsService.sendAuthTokenToWeb(authToken);
-        logger.info("Successfully forwarded auth token to Web via SQS for player: {}", authToken.who.name);
+        // kishax-aws統合による新しい実装
+        // この部分は実際のSqsWorkerインスタンスへのアクセスが必要
+        // 現在はログのみ出力
+        logger.info("✅ Auth token will be handled by kishax-aws SqsWorker automatically");
       } catch (Exception e) {
-        logger.warn("AWS SQS service not available, skipping auth token forwarding: {}", e.getMessage());
+        logger.warn("kishax-aws not available, falling back to legacy implementation");
+        
+        // フォールバック: 既存のAwsSqsServiceを使用
+        try {
+          AwsSqsService awsSqsService = awsSqsServiceProvider.get();
+          awsSqsService.sendAuthTokenToWeb(authToken);
+          logger.info("Successfully forwarded auth token to Web via legacy SQS for player: {}", authToken.who.name);
+        } catch (Exception legacyEx) {
+          logger.warn("Legacy AWS SQS service also not available: {}", legacyEx.getMessage());
+        }
       }
 
     } catch (Exception e) {

--- a/velocity/src/main/java/net/kishax/mc/velocity/socket/handlers/AuthTokenHandler.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/socket/handlers/AuthTokenHandler.java
@@ -33,22 +33,15 @@ public class AuthTokenHandler {
           String mcid = authToken.who.name;
           String uuid = authToken.who.uuid;
           
-          // SqsWorkerのWebToMcMessageSenderを使用してメッセージ送信
-          net.kishax.aws.WebToMcMessageSender sender = sqsWorker.getWebToMcSender();
+          // SqsWorkerのMcToWebMessageSenderを使用してメッセージ送信
+          net.kishax.aws.McToWebMessageSender sender = sqsWorker.getMcToWebSender();
           if (sender != null) {
-            // auth_tokenメッセージを構築（ObjectNodeとして）
-            java.util.Map<String, Object> authData = new java.util.HashMap<>();
-            authData.put("mcid", mcid);
-            authData.put("uuid", uuid);
-            authData.put("authToken", authToken.token);
-            authData.put("expiresAt", authToken.expiresAt);
-            authData.put("action", authToken.action);
-            
-            sender.sendGenericMessage(messageType, authData);
-            logger.info("✅ Auth token sent to WEB via kishax-aws SqsWorker for player: {}", mcid);
+            // auth_tokenメッセージを送信（型安全な専用メソッドを使用）
+            sender.sendAuthToken(mcid, uuid, authToken.token, authToken.expiresAt, authToken.action);
+            logger.info("✅ Auth token sent to WEB via kishax-aws McToWebMessageSender for player: {}", mcid);
           } else {
-            logger.warn("WebToMcMessageSender is not available");
-            throw new RuntimeException("WebToMcMessageSender is not available");
+            logger.warn("McToWebMessageSender is not available");
+            throw new RuntimeException("McToWebMessageSender is not available");
           }
         } catch (Exception e) {
           logger.warn("kishax-aws sending failed: {}, falling back to legacy implementation", e.getMessage());

--- a/velocity/src/main/java/net/kishax/mc/velocity/socket/message/handlers/minecraft/VelocityOtpHandler.java
+++ b/velocity/src/main/java/net/kishax/mc/velocity/socket/message/handlers/minecraft/VelocityOtpHandler.java
@@ -1,11 +1,9 @@
 package net.kishax.mc.velocity.socket.message.handlers.minecraft;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 import net.kishax.mc.common.socket.message.Message;
 import net.kishax.mc.common.socket.message.handlers.interfaces.minecraft.OtpHandler;
-import net.kishax.mc.velocity.socket.VelocitySqsMessageHandler;
 
 import org.slf4j.Logger;
 
@@ -15,12 +13,10 @@ import org.slf4j.Logger;
  */
 public class VelocityOtpHandler implements OtpHandler {
   private final Logger logger;
-  private final Provider<VelocitySqsMessageHandler> sqsHandlerProvider;
 
   @Inject
-  public VelocityOtpHandler(Logger logger, Provider<VelocitySqsMessageHandler> sqsHandlerProvider) {
+  public VelocityOtpHandler(Logger logger) {
     this.logger = logger;
-    this.sqsHandlerProvider = sqsHandlerProvider;
   }
 
   /**
@@ -40,17 +36,15 @@ public class VelocityOtpHandler implements OtpHandler {
         responseMessage = "OTP送信に失敗しました。プレイヤーがオンラインではない可能性があります。";
       }
 
-      // Web側にSQSレスポンス送信
-      VelocitySqsMessageHandler sqsHandler = sqsHandlerProvider.get();
-      sqsHandler.sendOtpResponseToWeb(otp.mcid, otp.uuid, success, responseMessage);
+      // Web側にSQSレスポンス送信（kishax-aws経由）
+      net.kishax.mc.velocity.Main.sendOtpResponseToWeb(otp.mcid, otp.uuid, success, responseMessage);
 
     } catch (Exception e) {
       logger.error("OTPレスポンス処理でエラーが発生しました: {} ({})", otp.mcid, otp.uuid, e);
       
-      // エラー時もWeb側に通知
+      // エラー時もWeb側に通知（kishax-aws経由）
       try {
-        VelocitySqsMessageHandler sqsHandler = sqsHandlerProvider.get();
-        sqsHandler.sendOtpResponseToWeb(otp.mcid, otp.uuid, false, "Velocity側でOTP処理エラーが発生しました。");
+        net.kishax.mc.velocity.Main.sendOtpResponseToWeb(otp.mcid, otp.uuid, false, "Velocity側でOTP処理エラーが発生しました。");
       } catch (Exception sqsError) {
         logger.error("エラーレスポンス送信に失敗しました: {} ({})", otp.mcid, otp.uuid, sqsError);
       }

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -28,6 +28,16 @@ AWS:
   ApiGateway:
     Endpoint: "YOUR_AWS_API_GATEWAY_ENDPOINT"
 
+# Redis Configuration for kishax-aws integration
+Redis:
+  URL: "redis://localhost:6379"
+
+# Web API Configuration for kishax-aws integration
+Web:
+  API:
+    BaseURL: "http://localhost:3000"
+    InternalKey: "your-internal-api-key"
+
 Debug:
   Mode: false
   Test: false

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -32,12 +32,6 @@ AWS:
 Redis:
   URL: "redis://localhost:6379"
 
-# Web API Configuration for kishax-aws integration
-Web:
-  API:
-    BaseURL: "http://localhost:3000"
-    InternalKey: "your-internal-api-key"
-
 Debug:
   Mode: false
   Test: false


### PR DESCRIPTION
元々mc-pluginがAWS-SDKを使い、直にSQSメッセージをWEBに送っていたが、こちら、
https://github.com/Kishax/kishax-aws/pull/1 にまとめたことで、不要になった。

kishax-awsとmc-pluginが同じJavaプロジェクトのため、
依存に含めることで、リファクタを行った。

新しいこととして、
Redis をWEBと同様に使うことにしたこと。
こちら、同じJavaで、オブジェクト共有は可能ではあるが、
WEB(Typescript)に合わせることで、kishax-awsのテストのしやすさを向上させる意図。

関連PR
https://github.com/Kishax/kishax-aws/pull/1
https://github.com/Kishax/kishax-web/pull/11