### PR TITLE
feat: MC認証完了通知機能とテストコマンドの実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,14 @@ API_GATEWAY_URL=https://YOUR_API_GATEWAY_ID.execute-api.ap-northeast-1.amazonaws
 
 
 # Kishax Application Settings
-CONFIRM_URL=https://your-confirm-url.com
 HOME_SERVER_NAME=spigot
 HOME_SERVER_IP=127.0.0.1
 
 # kishax-aws Integration Settings
-REDIS_URL=redis://localhost:6379
+# if you run local server, uncomment this line to pass the url to docker container
+# REDIS_URL=redis://localhost:6379
+
+# if you use production server, uncomment below
+# CONFIRM_URL=https://your-confirm-url.com
+
 QUEUE_MODE=MC

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 
   // Kishax AWS Integration - SQS and Redis communication
-  implementation 'net.kishax.aws:kishax-aws:1.0.2'
+  implementation 'net.kishax.aws:kishax-aws:1.0.3'
 }
 
 shadowJar {

--- a/common/src/main/java/net/kishax/mc/common/database/Database.java
+++ b/common/src/main/java/net/kishax/mc/common/database/Database.java
@@ -252,6 +252,32 @@ public class Database {
     return rowMap;
   }
 
+  /**
+   * テスト用メンバーをmembersテーブルに挿入
+   */
+  public int insertTestMember(Connection conn, String testPlayerName, String testPlayerUuid, String serverName) throws SQLException {
+    String insertQuery = """
+        INSERT INTO members (name, uuid, server, confirm, time, ban, member_id, hubinv, tptype, silent)
+        VALUES (?, ?, ?, 0, CURRENT_TIMESTAMP, 0, NULL, 1, 1, 0)
+        """;
+
+    try (PreparedStatement ps = conn.prepareStatement(insertQuery, PreparedStatement.RETURN_GENERATED_KEYS)) {
+      ps.setString(1, testPlayerName);
+      ps.setString(2, testPlayerUuid);
+      ps.setString(3, serverName);
+
+      int affectedRows = ps.executeUpdate();
+      if (affectedRows > 0) {
+        try (ResultSet generatedKeys = ps.getGeneratedKeys()) {
+          if (generatedKeys.next()) {
+            return generatedKeys.getInt(1); // 生成されたIDを返す
+          }
+        }
+      }
+    }
+    return -1; // 挿入失敗
+  }
+
   public int getPlayerTime(Connection conn, String playerUUID, int logId) throws SQLException {
     // 現在の時刻と最後のログの時刻の差を計算するメソッド
     String query = "SELECT * FROM log WHERE uuid=? AND `join`=? AND `id`=? ORDER BY id DESC LIMIT 1;";

--- a/common/src/main/java/net/kishax/mc/common/socket/SqsMessageHandler.java
+++ b/common/src/main/java/net/kishax/mc/common/socket/SqsMessageHandler.java
@@ -32,4 +32,11 @@ public interface SqsMessageHandler {
      * Web→MC OTP送信処理
      */
     void handleOtpToMinecraft(String mcid, String uuid, String otp);
+
+    /**
+     * 認証完了メッセージ処理
+     */
+    default void handleAuthCompletion(String playerName, String playerUuid, String message) {
+        // デフォルト実装は何もしない（拡張性のため）
+    }
 }

--- a/common/src/main/java/net/kishax/mc/common/socket/SqsMessageProcessor.java
+++ b/common/src/main/java/net/kishax/mc/common/socket/SqsMessageProcessor.java
@@ -126,6 +126,7 @@ public class SqsMessageProcessor {
             case "web_mc_command" -> processWebMcCommand(json);
             case "web_mc_player_request" -> processWebMcPlayerRequest(json);
             case "web_mc_otp" -> processWebMcOtp(json);
+            case "web_mc_auth_completion" -> processWebMcAuthCompletion(json);
             case "mc_otp_response" -> processMcOtpResponse(json);
             default -> {
                 logger.warn("不明なメッセージタイプです: {}", messageType);
@@ -171,11 +172,22 @@ public class SqsMessageProcessor {
         String playerName = json.path("playerName").asText();
         String playerUuid = json.path("playerUuid").asText();
         String otp = json.path("otp").asText();
-        
+
         logger.info("Web→MC OTP受信: {} ({}) OTP: {}", playerName, playerUuid, otp);
-        
+
         // OTP処理を実行
         messageHandler.handleOtpToMinecraft(playerName, playerUuid, otp);
+    }
+
+    private void processWebMcAuthCompletion(JsonNode json) {
+        String playerName = json.path("playerName").asText();
+        String playerUuid = json.path("playerUuid").asText();
+        String message = json.path("message").asText();
+
+        logger.info("Web→MC 認証完了通知受信: {} ({}) - {}", playerName, playerUuid, message);
+
+        // 認証完了処理を実行
+        messageHandler.handleAuthCompletion(playerName, playerUuid, message);
     }
 
     private void processMcOtpResponse(JsonNode json) {

--- a/compose.yml
+++ b/compose.yml
@@ -40,8 +40,9 @@ services:
       TZ: Asia/Tokyo
     volumes:
       - redis_data:/data
-    ports:
-      - "6379:6379"
+    # not portforwarded: default 6379 in only internal container network
+    # ports:
+    #   - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s

--- a/compose.yml
+++ b/compose.yml
@@ -66,7 +66,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
       SPIGOT_MEMORY: ${SPIGOT_MEMORY:-2G}
       VELOCITY_MEMORY: ${VELOCITY_MEMORY:-1G}
-      CONFIRM_URL: ${CONFIRM_URL:-https://your-confirm-url.com}
+      CONFIRM_URL: ${CONFIRM_URL:-http://localhost:3000/mc/auth}
       HOME_SERVER_NAME: ${HOME_SERVER_NAME:-spigot}
       HOME_SERVER_IP: ${HOME_SERVER_IP:-127.0.0.1}
       # AWS SQS Configuration
@@ -81,7 +81,7 @@ services:
       # Queue Mode Configuration for kishax-aws
       QUEUE_MODE: ${QUEUE_MODE:-MC}
       # Redis Configuration for kishax-aws
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     volumes:
       - minecraft_data:/mc/spigot/world
       - minecraft_data_nether:/mc/spigot/world_nether

--- a/spigot/svcore/src/main/java/net/kishax/mc/spigot/socket/SpigotSqsMessageHandler.java
+++ b/spigot/svcore/src/main/java/net/kishax/mc/spigot/socket/SpigotSqsMessageHandler.java
@@ -100,6 +100,50 @@ public class SpigotSqsMessageHandler implements SqsMessageHandler {
     logger.warn("SpigotSqsMessageHandlerでのOTP処理は廃止されました。Velocity→Spigot socket通信を使用してください。");
   }
 
+  @Override
+  public void handleAuthCompletion(String playerName, String playerUuid, String message) {
+    try {
+      logger.info("🎉 認証完了通知: {} ({}) - {}", playerName, playerUuid, message);
+
+      // Bukkitスケジューラで同期実行
+      Bukkit.getScheduler().runTask(plugin, () -> {
+        Player player = Bukkit.getPlayer(playerName);
+        if (player != null) {
+          // プレイヤーに認証完了メッセージを送信
+          player.sendMessage("§a" + message);
+          logger.info("認証完了メッセージをプレイヤーに送信しました: {}", playerName);
+        } else {
+          logger.warn("認証完了通知対象プレイヤーがオンラインではありません: {}", playerName);
+        }
+      });
+
+      // 将来の拡張のための処理を呼び出し
+      onAuthCompletionExtension(playerName, playerUuid, message);
+
+    } catch (Exception e) {
+      logger.error("認証完了処理でエラーが発生しました: {} ({})", playerName, playerUuid, e);
+    }
+  }
+
+  /**
+   * 認証完了時の拡張処理（将来の機能追加用）
+   *
+   * このメソッドは将来的に追加される認証完了後の処理のために用意されています。
+   * 現在は空の実装ですが、後で具体的な処理を追加することができます。
+   *
+   * 例：
+   * - 特別なエフェクトの表示
+   * - サウンドの再生
+   * - カスタムアイテムの付与
+   * - 権限の確認と追加付与
+   * - イベント統計の記録
+   */
+  protected void onAuthCompletionExtension(String playerName, String playerUuid, String message) {
+    // 拡張性のための空メソッド
+    // 将来的にここに追加の処理を実装できます
+    logger.debug("認証完了拡張処理: {} ({}) - 現在は何も実行しません", playerName, playerUuid);
+  }
+
   /**
    * テレポートコマンド処理
    */

--- a/spigot/svcore/src/main/java/net/kishax/mc/spigot/socket/message/handlers/minecraft/SpigotOtpHandler.java
+++ b/spigot/svcore/src/main/java/net/kishax/mc/spigot/socket/message/handlers/minecraft/SpigotOtpHandler.java
@@ -47,26 +47,49 @@ public class SpigotOtpHandler implements OtpHandler {
     try {
       logger.info("Velocity→Spigot OTP受信: {} ({}) OTP: {}", otp.mcid, otp.uuid, otp.otp);
 
+      // TEST_トークンの場合は追加のログ出力
+      boolean isTestMode = isTestToken(otp.mcid, otp.uuid);
+      if (isTestMode) {
+        logger.info("🧪 テストモードでのOTP処理を開始します");
+      }
+
       // メインスレッドで実行（Bukkit API呼び出しのため）
       Bukkit.getScheduler().runTask(plugin, () -> {
         Player player = Bukkit.getPlayer(otp.mcid);
         boolean success = false;
         String responseMessage;
-        
-        if (player != null && player.getUniqueId().toString().equals(otp.uuid)) {
-          // プレイヤーにOTPを送信
+
+        // テスト用プレイヤー（TestPlayer）とTEST_トークンの特別処理
+        if (otp.mcid.equals("TestPlayer") && otp.uuid.equals("00000000-0000-0000-0000-000000000000")) {
+          // テスト用プレイヤーの場合は常に成功として処理
+          success = true;
+          responseMessage = "テスト用プレイヤーのOTPを処理しました。";
+          logger.info("🧪 テスト用プレイヤー {} のOTPを処理しました: {}", otp.mcid, otp.otp);
+
+          // コンソールにOTP入力指示を表示
+          logger.info("=== テスト認証フロー ===");
+          logger.info("OTP: {} をWEBの方で入力してください！", otp.otp);
+          logger.info("======================");
+
+          // Bukkit コンソールにも出力
+          Bukkit.getConsoleSender().sendMessage("§a=== テスト認証フロー ===");
+          Bukkit.getConsoleSender().sendMessage("§eOTP: §b" + otp.otp + " §eをWEBの方で入力してください！");
+          Bukkit.getConsoleSender().sendMessage("§a======================");
+
+        } else if (player != null && player.getUniqueId().toString().equals(otp.uuid)) {
+          // 通常のプレイヤーにOTPを送信
           sendOtpToPlayer(player, otp.otp);
           success = true;
           responseMessage = "OTPをプレイヤーに送信しました。";
           logger.info("プレイヤー {} にOTPを送信しました: {}", player.getName(), otp.otp);
         } else {
-          String errorMessage = player == null 
+          String errorMessage = player == null
             ? "プレイヤーがオンラインではありません。"
             : "プレイヤーのUUIDが一致しません。";
           responseMessage = errorMessage;
           logger.warn("プレイヤーが見つからないかUUIDが一致しません: {} ({})", otp.mcid, otp.uuid);
         }
-        
+
         // Velocityにレスポンス送信
         sendOtpResponseToVelocity(otp.mcid, otp.uuid, success, responseMessage);
       });
@@ -132,5 +155,12 @@ public class SpigotOtpHandler implements OtpHandler {
     } catch (Exception e) {
       logger.error("VelocityへのOTPレスポンス送信でエラーが発生しました: {} ({})", mcid, uuid, e);
     }
+  }
+
+  /**
+   * テスト用トークンかどうかを判定
+   */
+  private boolean isTestToken(String mcid, String uuid) {
+    return mcid.equals("TestPlayer") && uuid.equals("00000000-0000-0000-0000-000000000000");
   }
 }

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
   //shadowImpl 'org.xerial:sqlite-jdbc:3.47.1.0'
   shadowImpl2 project(':common')
-  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.2'
+  shadowImpl2 'net.kishax.aws:kishax-aws:1.0.3'
 }
 
 build {


### PR DESCRIPTION
テスト通過

---

- SqsMessageHandlerに認証完了メッセージ処理のインターフェースを追加
- SqsMessageProcessorで認証完了メッセージタイプ処理を追加
- Velocityでプレイヤーへの直接メッセージ送信機能を実装
- Spigotで認証完了メッセージ処理と拡張用空メソッドを追加
- SpigotOtpHandlerにTestPlayer用特別処理を追加
- Spigotコンソール用「test kishax confirm」コマンドを実装
- Confirmクラスにテストフロー実行機能を追加
- Databaseクラスにテスト用メンバー自動作成機能を追加

🤖 Generated with [Claude Code](https://claude.ai/code)